### PR TITLE
update patch to match qt5-build.eclass as of 2022-04-21

### DIFF
--- a/qt5-build-eclass-nosse2.patch
+++ b/qt5-build-eclass-nosse2.patch
@@ -1,15 +1,15 @@
---- qt5-build.eclass.orig	2021-10-05 14:38:08.773024700 -0000
-+++ qt5-build.eclass	2021-10-05 14:40:30.673024700 -0000
-@@ -102,7 +102,7 @@
+--- qt5-build.eclass.orig	2022-04-20 21:42:30.967568052 -0400
++++ qt5-build.eclass	2022-04-20 21:38:52.497584358 -0400
+@@ -134,7 +134,7 @@
+ 		SLOT=5/$(ver_cut 1-2) ;;
+ esac
  
- LICENSE="|| ( GPL-2 GPL-3 LGPL-3 ) FDL-1.3"
- SLOT=5/$(ver_cut 1-2)
 -IUSE="debug test"
 +IUSE="cpu_flags_x86_sse2 debug test"
  
  if [[ ${QT5_BUILD_TYPE} == release ]]; then
- 	RESTRICT+=" test" # bug 457182
-@@ -537,6 +537,9 @@
+ 	RESTRICT="test" # bug 457182
+@@ -550,6 +550,9 @@
  		$(is-flagq -mno-dsp   && echo -no-mips_dsp)
  		$(is-flagq -mno-dspr2 && echo -no-mips_dspr2)
  


### PR DESCRIPTION
set this up on my pentium 3 machine, and the patch didn't apply after a sync.

this one does.